### PR TITLE
Specify that win32 is not supported

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"keywords": ["syslog", "rfc3164"],
 	"homepage": "https://github.com/moll/node-syslogh",
 	"bugs": "https://github.com/moll/node-syslogh/issues",
-
+	"os": [ "!win32" ],
 	"author": {
 		"name": "Andri Möll",
 		"email": "andri@dot.ee",


### PR DESCRIPTION
There is no reason to try and build where it always fails